### PR TITLE
fix type error for schemas

### DIFF
--- a/models/Plot.js
+++ b/models/Plot.js
@@ -1,12 +1,12 @@
 // This file contains the schema for a single 2x2 plot 
 const { Schema, model } = require("mongoose");
-const Plant = require("./plants");
+const { plantSchema } = require("./plants");
 
 const PLOT_SIZE_SQFT = 4;
 
 const plotSchema = new Schema({
 	plant: {
-		type: Object,
+		type: plantSchema,
 		required: false,
 	},
 	spaceMinimum: Number,
@@ -29,4 +29,7 @@ plotSchema.methods.findMaxPlants = function (cb) {
 
 const Plot = model("Plot", plotSchema);
 
-module.exports = Plot;
+module.exports = {
+	plotSchema,
+	default: Plot,
+};

--- a/models/garden.js
+++ b/models/garden.js
@@ -1,5 +1,5 @@
 const mongoose = require("mongoose");
-const Plot = require("./plot");
+const { plotSchema } = require("./plot");
 
 
 const Schema = mongoose.Schema;
@@ -7,6 +7,7 @@ const Schema = mongoose.Schema;
 const gardenSchema = new Schema({
   plots: {
     type: Array,
+    of: plotSchema,
     required: false,
   },
 

--- a/models/plants.js
+++ b/models/plants.js
@@ -50,4 +50,7 @@ const plantSchema = new Schema({
 
 const Plant = mongoose.model("Plant", plantSchema);
 
-module.exports = Plant;
+module.exports = {
+  plantSchema,
+  default: Plant
+};


### PR DESCRIPTION
* stricter typing in the models using subschemas
* plant and plot model files now export plant and plot schemas in addition to default Plant and Plot mongoose models
* plots are now able to have a plant of type plant instead of type object
* gardens now have an array of type plot instead of an array of undefined type 